### PR TITLE
Fix composer version error at Drupal 10

### DIFF
--- a/drupal/10.0.x/config.yml
+++ b/drupal/10.0.x/config.yml
@@ -12,6 +12,7 @@ services:
         - chmod +x /usr/local/bin/drush
         - echo "memory_limit = 2G" >> /usr/local/etc/php/conf.d/my-php.ini
       update:
+        - composer self-update
         - composer install --optimize-autoloader
         - COMPOSER_ROOT_VERSION="${TUGBOAT_GITLAB_TARGET:-$TUGBOAT_PREVIEW}-dev" composer require drush/drush
         - mkdir -p "${DOCROOT}/sites/default/files"
@@ -20,6 +21,7 @@ services:
         - find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
         - drush --yes --db-url=mysql://tugboat:tugboat@mysql:3306/tugboat --account-name=admin --account-pass=admin site:install standard
       build:
+        - composer self-update
         - composer install --optimize-autoloader
         - COMPOSER_ROOT_VERSION="${TUGBOAT_GITLAB_TARGET:-$TUGBOAT_PREVIEW}-dev" composer require drush/drush
         - drush updatedb -y


### PR DESCRIPTION
Fixes the following error:

```
2023-04-06T00:03:09.457Z - 625861b3bda4981539f6e611# /bin/sh -c composer install --optimize-autoloader
> Drupal\Composer\Composer::ensureComposerVersion
Script Drupal\Composer\Composer::ensureComposerVersion handling the pre-install-cmd event terminated with an exception

                                                                                                                        
  [RuntimeException]                                                                                                    
  Drupal core development requires Composer 2.3.6, but Composer 2.2.9 is installed. Please run 'composer self-update'.  
                                                                                                                        
```