### PR TITLE
Add config for 10.1.x

### DIFF
--- a/drupal/10.1.x/config.yml
+++ b/drupal/10.1.x/config.yml
@@ -1,0 +1,30 @@
+services:
+  php:
+    image: tugboatqa/php:8.1-apache
+    default: true
+    depends: mysql
+    commands:
+      init:
+        - docker-php-ext-install opcache
+        - a2enmod headers rewrite
+        - ln -snf $TUGBOAT_ROOT $DOCROOT
+        - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        - chmod +x /usr/local/bin/drush
+        - echo "memory_limit = 2G" >> /usr/local/etc/php/conf.d/my-php.ini
+      update:
+        - composer self-update
+        - composer install --optimize-autoloader
+        - COMPOSER_ROOT_VERSION="${TUGBOAT_GITLAB_TARGET:-$TUGBOAT_PREVIEW}-dev" composer require drush/drush
+        - mkdir -p "${DOCROOT}/sites/default/files"
+        - chgrp -R www-data "${DOCROOT}/sites/default/files"
+        - find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;
+        - find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
+        - drush --yes --db-url=mysql://tugboat:tugboat@mysql:3306/tugboat --account-name=admin --account-pass=admin site:install standard
+      build:
+        - composer self-update
+        - composer install --optimize-autoloader
+        - COMPOSER_ROOT_VERSION="${TUGBOAT_GITLAB_TARGET:-$TUGBOAT_PREVIEW}-dev" composer require drush/drush
+        - drush updatedb -y
+        - drush cache:rebuild
+  mysql:
+    image: tugboatqa/mariadb:10


### PR DESCRIPTION
Copying it from 10.0.x. Saw https://dashboard.tugboatqa.com/642897c3497d68d0b81b618d failed with the following error because 10.1.x is using the config from https://github.com/TugboatQA/drupalorg/tree/master/drupal/default.